### PR TITLE
Swedish date format is d/m/Y not m/d/Y

### DIFF
--- a/src/mod/say/mod_say_sv/mod_say_sv.c
+++ b/src/mod/say/mod_say_sv/mod_say_sv.c
@@ -419,11 +419,11 @@ static switch_status_t sv_say_time(switch_say_file_handle_t *sh, char *tosay, sw
                 say_today = say_yesterday = 0;
         }
 
+	if (say_day) {
+                say_num(sh, tm.tm_mday, SSM_COUNTED);
+        }
         if (say_month) {
                 switch_say_file(sh, "time/mon-%d", tm.tm_mon);
-        }
-        if (say_day) {
-                say_num(sh, tm.tm_mday, SSM_COUNTED);
         }
         if (say_year) {
                 say_num(sh, tm.tm_year + 1900, SSM_PRONOUNCED_YEAR);


### PR DESCRIPTION
This should fix the malformed date format when reading the date of recorded voicemails in swedish.