### PR TITLE
[mod_voicemail] Add option to prevent password change

### DIFF
--- a/src/mod/applications/mod_voicemail/conf/autoload_configs/voicemail.conf.xml
+++ b/src/mod/applications/mod_voicemail/conf/autoload_configs/voicemail.conf.xml
@@ -46,6 +46,7 @@
       <param name="web-template-file" value="web-vm.tpl"/>
       <param name="db-password-override" value="false"/>
       <param name="allow-empty-password-auth" value="true"/>
+      <param name="allow-password-change" value="true"/>
       <!-- if you need to change the sample rate of the recorded files e.g. gmail voicemail player -->
       <!--<param name="record-sample-rate" value="11025"/>-->
       <!-- the next two both must be set for this to be enabled

--- a/src/mod/applications/mod_voicemail/mod_voicemail.c
+++ b/src/mod/applications/mod_voicemail/mod_voicemail.c
@@ -181,6 +181,7 @@ struct vm_profile {
 	switch_bool_t auto_playback_recordings;
 	switch_bool_t db_password_override;
 	switch_bool_t allow_empty_password_auth;
+	switch_bool_t allow_password_change;
 	switch_bool_t send_full_vm_header;
 	switch_thread_rwlock_t *rwlock;
 	switch_memory_pool_t *pool;
@@ -689,6 +690,8 @@ vm_profile_t *profile_set_config(vm_profile_t *profile)
 						   &profile->db_password_override, SWITCH_FALSE, NULL, NULL, NULL);
 	SWITCH_CONFIG_SET_ITEM(profile->config[i++], "allow-empty-password-auth", SWITCH_CONFIG_BOOL, CONFIG_RELOADABLE,
 						   &profile->allow_empty_password_auth, SWITCH_TRUE, NULL, NULL, NULL);
+	SWITCH_CONFIG_SET_ITEM(profile->config[i++], "allow-password-change", SWITCH_CONFIG_BOOL, CONFIG_RELOADABLE,
+						   &profile->allow_password_change, SWITCH_TRUE, NULL, NULL, NULL);
 	SWITCH_CONFIG_SET_ITEM(profile->config[i++], "auto-playback-recordings", SWITCH_CONFIG_BOOL, CONFIG_RELOADABLE, &profile->auto_playback_recordings, SWITCH_FALSE, NULL, NULL, NULL);
 	SWITCH_CONFIG_SET_ITEM(profile->config[i++], "send-full-vm-header", SWITCH_CONFIG_BOOL, CONFIG_RELOADABLE, &profile->send_full_vm_header, SWITCH_FALSE, NULL, NULL, NULL);
 
@@ -2305,7 +2308,7 @@ static void voicemail_check_main(switch_core_session_t *session, vm_profile_t *p
 						switch_safe_free(file_path);
 					}
 
-				} else if (!strcmp(input, profile->change_pass_key)) {
+				} else if (!strcmp(input, profile->change_pass_key) && profile->allow_password_change) {
 					char buf[256] = "";
 					char macro[256] = "";
 					switch_event_t *params;


### PR DESCRIPTION
With introduction of the param `allow-password-change`, we can change if
users are able to change password or not. Defaults to true.